### PR TITLE
fix qbit cann't ban IPV6 address with [].

### DIFF
--- a/main.py
+++ b/main.py
@@ -134,7 +134,8 @@ class VampireHunter:
             if now > value['expired']:
                 del self.__banned_ips[key]
                 continue
-            ips += key + '\n'
+            ip = key.strip('[]')  # 去除IPV6地址字符串中的大括号
+            ips += ip + '\n'
         self.SESSION.post(
             f'{self.API_FULL}/app/setPreferences',
             auth=self.get_basicauth(),


### PR DESCRIPTION
在我使用的 qBittorrent 版本v4.5.2中，发现对于 IPV6 地址的 IP ，需要去掉大括号才能正常添加进阻止的 IP 列表，我所用版本测试通过。
![image](https://github.com/Ghost-chu/qb-ban-vampire-docker/assets/19749321/0a027cc4-0b3a-4573-bcb1-cbaaa1282523)
